### PR TITLE
Keep cargo native progress bars

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,13 +18,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28ae2b3dec75a406790005a200b1bd89785afc02517a00ca99ecfe093ee9e6cf"
 
 [[package]]
+name = "camino"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52d74260d9bf6944e2208aa46841b4b8f0d7ffc0849a06837b2f510337f86b2b"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "cargo-firstpage"
 version = "0.1.2"
 dependencies = [
  "anyhow",
+ "cargo_metadata",
+ "serde_json",
  "terminal_size",
  "textwrap",
 ]
+
+[[package]]
+name = "cargo-platform"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbdb825da8a5df079a43676dbe042702f1707b1109f713a01420fbb4cc71fa27"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "cargo_metadata"
+version = "0.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba2ae6de944143141f6155a473a6b02f66c7c3f9f47316f802f80204ebfe6e12"
+dependencies = [
+ "camino",
+ "cargo-platform",
+ "semver",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
 
 [[package]]
 name = "libc"
@@ -37,6 +76,24 @@ name = "memchr"
 version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
+
+[[package]]
+name = "proc-macro2"
+version = "1.0.34"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f84e92c0f7c9d58328b85a78557813e4bd845130db68d7184635344399423b1"
+dependencies = [
+ "unicode-xid",
+]
+
+[[package]]
+name = "quote"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "38bc8cc6a5f2e3655e0899c1b848643b2562f853f114bfec7be120678e3ace05"
+dependencies = [
+ "proc-macro2",
+]
 
 [[package]]
 name = "regex"
@@ -56,10 +113,67 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
+name = "ryu"
+version = "1.0.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
+
+[[package]]
+name = "semver"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "568a8e6258aa33c13358f81fd834adb854c6f7c9468520910a9b1e8fac068012"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "serde"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b9875c23cf305cd1fd7eb77234cbb705f21ea6a72c637a5c6db5fe4b8e7f008"
+dependencies = [
+ "serde_derive",
+]
+
+[[package]]
+name = "serde_derive"
+version = "1.0.132"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc0db5cb2556c0e558887d9bbdcf6ac4471e83ff66cf696e5419024d1606276"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bcbd0344bc6533bc7ec56df11d42fb70f1b912351c0825ccb7211b59d8af7cf5"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
 name = "smawk"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f67ad224767faa3c7d8b6d91985b78e70a1324408abcb1cfcc2be4c06bc06043"
+
+[[package]]
+name = "syn"
+version = "1.0.82"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8daf5dd0bb60cbd4137b1b587d2fc0ae729bc07cf01cd70b36a1ed5ade3b9d59"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-xid",
+]
 
 [[package]]
 name = "terminal_size"
@@ -96,6 +210,12 @@ name = "unicode-width"
 version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9337591893a19b88d8d87f2cec1e73fad5cdfd10e5a6f349f498ad6ea2ffb1e3"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
 
 [[package]]
 name = "winapi"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,5 +13,7 @@ categories = ["development-tools::cargo-plugins"]
 
 [dependencies]
 anyhow = "1"
+cargo_metadata = "0.14.1"
+serde_json = "1.0.73"
 terminal_size = "0.1"
 textwrap = "0.14"

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,11 @@ fn main() -> Result<()> {
 
     command.arg(subcommand);
 
-    if SHOWS_ERRORS.contains(&subcommand) && args.iter().all(|arg| !SPECIAL_ARGS.contains(&&**arg))
+    if SHOWS_ERRORS.contains(&subcommand)
+        && args
+            .iter()
+            .take_while(|arg| *arg != "--")
+            .all(|arg| !SPECIAL_ARGS.contains(&&**arg))
     {
         command.arg("--message-format=json-diagnostic-rendered-ansi");
         // TODO: Piping stdout will not disable colors emitted by Cargo itself (as those are done

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,8 @@ const SHOWS_ERRORS: &[&str] = &[
     "rustc", "rustdoc", "t", "test",
 ];
 
+const SPECIAL_ARGS: &[&str] = &["--help", "-h", "--version", "-V"];
+
 fn main() -> Result<()> {
     let mut args = std::env::args().peekable();
     let _command = args.next();
@@ -47,6 +49,8 @@ fn main() -> Result<()> {
         Some(subcommand) => subcommand,
     };
 
+    let args = args.collect::<Vec<_>>();
+
     let (width, height) = if let Some((Width(width), Height(height))) = terminal_size() {
         (width as usize, height as usize)
     } else {
@@ -57,7 +61,8 @@ fn main() -> Result<()> {
 
     command.arg(subcommand);
 
-    if SHOWS_ERRORS.contains(&subcommand) {
+    if SHOWS_ERRORS.contains(&subcommand) && args.iter().all(|arg| !SPECIAL_ARGS.contains(&&**arg))
+    {
         command.arg("--message-format=json-diagnostic-rendered-ansi");
         // TODO: Piping stdout will not disable colors emitted by Cargo itself (as those are done
         // via stderr), but it can disable colors for programs that Cargo then spawns that use

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,36 +1,51 @@
-use anyhow::{bail, Context, Result};
-use std::io::{BufRead, BufReader};
+use anyhow::{anyhow, bail, Context, Result};
+use cargo_metadata::Message;
+use std::cmp;
+use std::io::{self, BufRead, BufReader, Write};
 use std::process::{Command, Stdio};
 use terminal_size::{terminal_size, Height, Width};
 use textwrap::wrap;
 
 // This probably depends on the user's prompt size
-const SPACE_AROUND: usize = 2;
+const SPACE_AROUND: usize = 4;
+
+const HELP: &str = r#"A wrapper for Cargo that displays only the first page of errors.
+
+USAGE:
+    cargo firstpage -h|--help
+    cargo firstpage [COMMAND] [args]...
+"#;
+
+/// A list of Cargo subcommands that show errors and support
+/// `--message-format=json-diagnostic-rendered-ansi`.
+///
+/// Some Cargo subcommands can show diagnostics but do not support that option:
+/// - `cargo fmt`
+/// - `cargo install`
+/// - `cargo package`
+/// - `cargo publish`
+///
+/// Users are not likely to encouter diagnostics with these commands anyway however, so it's fine
+/// to not attempt to cut off their output.
+const SHOWS_ERRORS: &[&str] = &[
+    "b", "bench", "build", "c", "check", "clippy", "d", "doc", "fix", "init", "miri", "r", "run",
+    "rustc", "rustdoc", "t", "test",
+];
 
 fn main() -> Result<()> {
     let mut args = std::env::args().peekable();
     let _command = args.next();
+    // Support running both as `cargo-firstpage` and as `cargo firstpage`.
     args.next_if(|x| x.as_str() == "firstpage");
 
-    let mut child = Command::new("cargo")
-        .env("CARGO_TERM_COLOR", "always")
-        .args(args)
-        .stderr(Stdio::piped())
-        .spawn()
-        .context("could not start cargo command")?;
-    let mut output = BufReader::new(child.stderr.take().unwrap());
-
-    let mut buf = String::new();
-    while output.read_line(&mut buf)? > 0 {
-        if !buf.starts_with(' ') {
-            break;
+    let subcommand_arg = args.next();
+    let subcommand = match subcommand_arg.as_deref() {
+        Some("--help" | "-h") | None => {
+            print!("{}", HELP);
+            return Ok(());
         }
-
-        eprint!("{}", buf);
-
-        buf.clear();
-    }
-    eprintln!();
+        Some(subcommand) => subcommand,
+    };
 
     let (width, height) = if let Some((Width(width), Height(height))) = terminal_size() {
         (width as usize, height as usize)
@@ -38,24 +53,66 @@ fn main() -> Result<()> {
         bail!("could not get terminal size");
     };
 
-    let mut count = 0;
-    while output.read_line(&mut buf)? > 0 {
-        let lines = wrap(buf.trim_end(), width);
-        count += lines.len();
+    let mut command = Command::new(std::env::var_os("CARGO").unwrap_or_else(|| "cargo".into()));
 
-        if count > height - SPACE_AROUND {
-            break;
-        }
+    command.arg(subcommand);
 
-        for line in lines {
-            eprintln!("{}", line);
-        }
-
-        buf.clear();
+    if SHOWS_ERRORS.contains(&subcommand) {
+        command.arg("--message-format=json-diagnostic-rendered-ansi");
+        // TODO: Piping stdout will not disable colors emitted by Cargo itself (as those are done
+        // via stderr), but it can disable colors for programs that Cargo then spawns that use
+        // stdout (such as the default test runner in `cargo test`). To solve this properly, we
+        // would have to spawn these commands in a PTY and forward the PTY output.
+        command.stdout(Stdio::piped());
     }
 
-    let mut sink = std::io::sink();
-    let _ = std::io::copy(&mut output, &mut sink);
+    command.args(args);
+
+    let mut child = command.spawn().context("could not start cargo command")?;
+
+    // `child.stdout` can be `None` if `shows_errors == false`.
+    if let Some(stdout) = child.stdout.take() {
+        let mut stdout = BufReader::new(stdout);
+
+        let mut diagnostics = String::new();
+
+        let mut buf = String::new();
+
+        while stdout.read_line(&mut buf)? > 0 {
+            match serde_json::from_str(&buf) {
+                Ok(Message::CompilerMessage(msg)) => {
+                    let rendered = msg
+                        .message
+                        .rendered
+                        .context("rustc did not provide rendered message")?;
+                    diagnostics.push_str(&rendered);
+                }
+                Ok(Message::BuildFinished(_)) => break,
+                Ok(_) => {}
+                Err(e) => {
+                    bail!(anyhow!(e).context("could not deserialize Cargo message"));
+                }
+            }
+            buf.clear();
+        }
+
+        // Now that Cargo has finished emitting its diagnostics, pipe the rest of stdout directly.
+        io::copy(&mut stdout, &mut io::stdout().lock())?;
+
+        // Removing trailing newlines avoids double-newlines at the end of the output.
+        if diagnostics.ends_with('\n') {
+            diagnostics.pop();
+        }
+
+        if !diagnostics.is_empty() {
+            let lines = wrap(&diagnostics, width);
+            let stderr = io::stderr();
+            let mut stderr = stderr.lock();
+            for line in &lines[..cmp::min(lines.len(), height - SPACE_AROUND)] {
+                writeln!(stderr, "{}", line)?;
+            }
+        }
+    }
 
     if let Ok(status) = child.wait() {
         std::process::exit(status.code().unwrap_or_default());


### PR DESCRIPTION
It's nice to have Cargo's native progress bars when building. To achieve this I used a slightly different approach to the current one: `firstpage` will detect if a Cargo subcommand is being used that supports the option `--message-format=json-diagnostic-rendered-ansi`. If not, it will simply run the inner command unchanged, but if so, it will pass that option in.

The Cargo subcommand will then output diagnostic JSON to stdout and its UI stuff (like green "Compiling" messages and the progress bar) to stderr. Only stdout will be piped, and `firstpage` can then process this JSON and to display it once it has been line-wrapped and limited in vertical size.

I had all the diagnostics be emitted after Cargo finished its compilation fully (instead of during) which is a slight change in behaviour, but there isn't really another option since printing it out as it comes in results in the two processes racing to stdout and message tearing. It's also arguably more useful because the message "could not compile `{crate name}` due to N previous errors" will be actually visible instead of cut off at the bottom.

I added a help menu also. Mostly because I needed something to do if `cargo firstpage` was run without arguments, since I can no longer rely on Cargo to cause the error itself.